### PR TITLE
update shortcut for go-to-line

### DIFF
--- a/emacs-tutor/emacs-tutor.org
+++ b/emacs-tutor/emacs-tutor.org
@@ -995,7 +995,7 @@ These key bindings are in Emacs only:
 - Move to top of the buffer: *M-<*
 - Move to end of the buffer: *M->*
 - Move to the nth character: *M-g c* (c stands for =character=)
-- Move to the nth line: *M-g l* (l stands for =line=)
+- Move to the nth line: *M-g l* (*M-g g* for emacs >= 23.2) (l/g stands for =line=)
 
 Recenter means making the current line point is on the center of
 your screen.


### PR DESCRIPTION
regarding go-to-line - http://www.emacswiki.org/emacs/GotoLine
about "recentering" - I was unable to get it working on my emacs24 (ubuntu, fresh installation). Manual describes a bit different shortcuts: https://www.gnu.org/software/emacs/manual/html_node/emacs/Recentering.html
