### PR TITLE
jump-to-register is useless for text registers

### DIFF
--- a/emacs-tutor/emacs-tutor.org
+++ b/emacs-tutor/emacs-tutor.org
@@ -2264,9 +2264,6 @@ You can also save a region in registers.
 | *C-x r i REG* | *Command*: =insert-register=    |
 |               | Insert text from register *REG* |
 |---------------+---------------------------------|
-| *C-x r j REG* | *Command*: =jump-to-register=   |
-|               | Jump to a register *REG*.       |
-|---------------+---------------------------------|
 
 *REG* can be a letter (such as ‘a’) or a number (such as ‘1’); case
  matters, so register ‘a’ is not the same as register ‘A’.


### PR DESCRIPTION
jump-to-register: Register doesn't contain a buffer position or configuration
