### PR TITLE
incorrect keybinding?

### DIFF
--- a/emacs-tutor/emacs-tutor.org
+++ b/emacs-tutor/emacs-tutor.org
@@ -2449,7 +2449,7 @@ have to repeat yourself, using macro. Follow these steps:
 
 - Place point at the beginning of the first line.
 - Press *<f3>*.
-- Use *C-f* to move to the beginning of each character group and add whitespace.
+- Use C-s to search-and-jump to the beginning of each character group (or C-f if you want something simple) and add whitespace. 
 - Return to the beginning of next line. Press *<f4>* to finish recording.
 - Continuously press *<f4>* and see Emacs playbacks the whole action
   sequence you've just recorded.


### PR DESCRIPTION
on emacs 24.2 and emacs 24.3.93.1 - `C-s` in regular buffer is for `I-search` (as it is supposed to be)
