### PR TITLE
C-c C-b is to execute file, not C-c C-z

### DIFF
--- a/emacs-tutor/emacs-for-proglang.org
+++ b/emacs-tutor/emacs-for-proglang.org
@@ -674,7 +674,7 @@ you comfortable with the course.
   module. *C-c C-a* automatically evaluates the file of current
   working buffer and switch context to that module. Note that if you
   haven't save your buffer, Geiser will use the last saved state. You
-  can also use *C-c C-z* to execute current file without switching to
+  can also use *C-c C-b* to execute current file without switching to
   the REPL. This is useful when you want to write and run test
   continuously, i.e. write a few tests then execute, then write a few
   more and test a few more etc...


### PR DESCRIPTION
This fixes the typo where it says "You can also use _C-c C-z_ to execute current file" to "You can also use _C-c C-b_ to execute current file" which is the correct command for executing the current file in geiser. C-c C-z switches to the repl buffer
