### PR TITLE
Helm Intro - Added Table with List of Key Bindings

### DIFF
--- a/emacs-tutor/helm-intro.org
+++ b/emacs-tutor/helm-intro.org
@@ -1525,7 +1525,7 @@ This chapter summarizes the key bindings introduced in the above chapters.
 | =C-c h g=     | =helm-google-suggest=             | Interactively enter search terms and get results from Google in helm buffer |
 | =C-c h c=     | =helm-color=                      | Lists all available faces                                                   |
 | =C-c h M-:=   | =helm-eval-expression-with-eldoc= | Get instant results for emacs lisp expressions in the helm buffer           |
-| =C-c h C-, =  | =helm-calcul-expression=          | Helm interface to calc                                                      |
+| =C-c h C-=,   | =helm-calcul-expression=          | Helm interface to calc                                                      |
 | =C-c C-l=     | =helm-eshell-history=             | Interface to eshell history                                                 |
 | =C-c C-l=     | =helm-comint-input-ring=          | Interface to shell history                                                  |
 | =C-c C-l=     | =helm-mini-buffer-history=        | Interface to mini-buffer history                                            |

--- a/emacs-tutor/helm-intro.org
+++ b/emacs-tutor/helm-intro.org
@@ -1525,7 +1525,7 @@ This chapter summarizes the key bindings introduced in the above chapters.
 | =C-c h g=     | =helm-google-suggest=             | Interactively enter search terms and get results from Google in helm buffer |
 | =C-c h c=     | =helm-color=                      | Lists all available faces                                                   |
 | =C-c h M-:=   | =helm-eval-expression-with-eldoc= | Get instant results for emacs lisp expressions in the helm buffer           |
-| =C-c h C-,=   | =helm-calcul-expression=          | Helm interface to calc                                                      |
+| =C-c h C-, =  | =helm-calcul-expression=          | Helm interface to calc                                                      |
 | =C-c C-l=     | =helm-eshell-history=             | Interface to eshell history                                                 |
 | =C-c C-l=     | =helm-comint-input-ring=          | Interface to shell history                                                  |
 | =C-c C-l=     | =helm-mini-buffer-history=        | Interface to mini-buffer history                                            |

--- a/emacs-tutor/helm-intro.org
+++ b/emacs-tutor/helm-intro.org
@@ -1248,7 +1248,7 @@ _Demo_:
 :ID:       6e010b94-e671-40f4-9a5a-31e54ba00bdd
 :END:
 _Key binding_:
-n
+
 *<prefix> c* (prefix is *C-x c* by default, or *C-c h* if set).
 
 _Description_:
@@ -1491,3 +1491,42 @@ _Usage_:
 
 Enter a prefix key and *C-h* after it. You will see a list of bindings
 using Helm interface for narrowing.
+
+* Summary of Keybindings
+:PROPERTIES:
+:ID:       68003d84-9f41-11e4-89d3-123b93f75cba
+:END:
+
+This chapter summarizes the key bindings introduced in the above chapters.
+
+| Key Binding   | Command                           | Description                                                                 |
+|---------------+-----------------------------------+-----------------------------------------------------------------------------|
+| =M-x=         | =helm-M-x=                        | List commands                                                               |
+| =M-y=         | =helm-show-kill-ring=             | Shows the content of the kill ring                                          |
+| =C-x b=       | =helm-mini=                       | Shows open buffers, recently opened files                                   |
+| =C-x C-f=     | =helm-find-files=                 | The helm version for find-file                                              |
+| =C-s=         | =helm-ff-run-grep=                | Run grep from within helm-find-files                                        |
+| =C-c h i=     | =helm-semantic-or-imenu=          | Helm interface to semantic/imenu                                            |
+| =C-c h m=     | =helm-man-woman=                  | Jump to any man entry                                                       |
+| =C-c h /=     | =helm-find=                       | Helm interface to find                                                      |
+| =C-c h l=     | =helm-locate=                     | Helm interface to locate                                                    |
+| =C-c h o=     | =helm-occur=                      | Similar to occur                                                            |
+| =C-c h a=     | =helm-apropos=                    | Describes commands, functions, variables, ...                               |
+| =C-c h h g=   | =helm-info-gnus=                  |                                                                             |
+| =C-c h h i=   | =helm-info-at-point=              |                                                                             |
+| =C-c h h r=   | =helm-info-emacs=                 |                                                                             |
+| =C-c h <tab>= | =helm-lisp-completion-at-point=   | Provides a list of available functions                                      |
+| =C-c h b=     | =helm-resume=                     | Resumes a previous helm session                                             |
+| =C-h SPC=     | =helm-all-mark-rings=             | Views content of local and global mark rings                                |
+| =C-c h r=     | =helm-regex=                      | Visualizes regex matches                                                    |
+| =C-c h x=     | =helm-register=                   | Shows content of registers                                                  |
+| =C-c h t=     | =helm-top=                        | Helm interface to top                                                       |
+| =C-c h s=     | =helm-surfraw=                    | Command line interface to many web search engines                           |
+| =C-c h g=     | =helm-google-suggest=             | Interactively enter search terms and get results from Google in helm buffer |
+| =C-c h c=     | =helm-color=                      | Lists all available faces                                                   |
+| =C-c h M-:=   | =helm-eval-expression-with-eldoc= | Get instant results for emacs lisp expressions in the helm buffer           |
+| =C-c h C-,=   | =helm-calcul-expression=          | Helm interface to calc                                                      |
+| =C-c C-l=     | =helm-eshell-history=             | Interface to eshell history                                                 |
+| =C-c C-l=     | =helm-comint-input-ring=          | Interface to shell history                                                  |
+| =C-c C-l=     | =helm-mini-buffer-history=        | Interface to mini-buffer history                                            |
+

--- a/emacs-tutor/helm-projectile.org
+++ b/emacs-tutor/helm-projectile.org
@@ -457,7 +457,7 @@ key.
 
 - /Print File/ (*C-c p*, add *C-u* to refresh): Print marked files.
 
-** Command: ~helm-projectile-find-file-in-known-projects~~, *C-c p F*
+** Command: ~helm-projectile-find-file-in-known-projects~, *C-c p F*
 :PROPERTIES:
 :ID:       1a36aba8-2070-4f66-b98e-efc66fc2b304
 :END:
@@ -831,3 +831,26 @@ these variables to ignore files or directories:
  to ignore in =helm-projectile-grep=, i.e. ~backup~ not
  ~personal/backup~, but with =helm-projectile-ag=, either ~backup~ or
  ~personal/backup~ works fine.
+* Summary of Keybindings
+:PROPERTIES:
+:ID:       68003d84-9f41-11e4-89d3-123b93f75cbb
+:END:
+
+This chapter summarizes the key bindings introduced in the above chapters.
+
+| Key Binding | Command                                       | Description                                                  |
+|-------------+-----------------------------------------------+--------------------------------------------------------------|
+| =C-c p h=   | =helm-projectile=                             | Helm interface to projectile                                 |
+| =C-c p p=   | =helm-projectile-switch-project=              | Switches to another projectile project                       |
+| =C-c p f=   | =helm-projectile-find-file=                   | Lists all files in a project                                 |
+| =C-c p F=   | =helm-projectile-find-file-in-known-projects= | Find file in all known projects                              |
+| =C-c p g=   | =helm-projectile-find-file-dwim=              | Find file based on context at point                          |
+| =C-c p d=   | =helm-projectile-find-dir=                    | Lists available directories in current project               |
+| =C-c p e=   | =helm-projectile-recentf=                     | Lists recently opened files in current project               |
+| =C-c p a=   | =helm-projectile-find-other-file=             | Switch between files with same name but different extensions |
+| =C-c p i=   | =projectile-invalidate-cache=                 | Invalidate cache                                             |
+| =C-c p z=   | =projectile-cache-current-file=               | Add the file of current selected buffer to cache             |
+| =C-c p b=   | =helm-projectile-switch-to-buffer=            | List all open buffers in current project                     |
+| =C-c p s g= | =helm-projectile-grep=                        | Searches for symbol starting from project root               |
+| =C-c p s a= | =helm-projectile-ack=                         | Same as above but using ack                                  |
+| =C-c p s s= | =helm-projectile-ag=                          | Same as above but using ag                                   |


### PR DESCRIPTION
Hi,

I really learned a lot reading your helm intro pages. I've added a chapter for the helm-intro and the helm-projectile-intro where the keybindings introduced/defined are listed in a table at the bottom of the document.

Please note that I had issues with the markup. The following

 =C-c h C-,=

screwed up the table layout. I tried all sort of escapings but none were working (I'm not an org-mode master...). I finally ended up using

  =C-c h C-=,

which is not nice but at least the table is not broken anymore.

Regards,
Andreas

PS: I also removed two typos ;)