### PR TITLE
Warn about old GNU Global packages in distro repos

### DIFF
--- a/c-ide.html
+++ b/c-ide.html
@@ -499,7 +499,9 @@ use, read the guide <a href="emacs-tutor3.html">How to use Emacs package manager
 
 <li>Have <a href="http://www.gnu.org/software/global/">GNU Global</a> installed. Download the source <a href="http://www.gnu.org/software/global/download.html">here</a>, or you can
 install it from the package manager of your OS (Linux distribution
-or Mac OS). For Windows users, download the <a href="http://adoxa.altervista.org/global/">Win32 port</a>.
+or Mac OS). Warning: if you install from a package manager, check that you don't get an outdated version 
+(helm-gtags might not fully work otherwise).   
+For Windows users, download the <a href="http://adoxa.altervista.org/global/">Win32 port</a>.
 </li>
 
 <li>Install <a href="https://github.com/leoliu/ggtags">ggtags</a>. After installing <code>ggtags</code> from MELPA, add this code


### PR DESCRIPTION
Ubuntu (and probably Debian too) packages gnu global 5.7.1. I could not get helm-gtags-update-tags to successfully update tags until I upgraded to the latest global (built from source). This was hard to track down, so I'd hate others to make the same mistake!