### PR TITLE
Use https to load font

### DIFF
--- a/emacs-tutor/static/worg.css
+++ b/emacs-tutor/static/worg.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans+Mono|Droid+Serif);
+@import url(https://fonts.googleapis.com/css?family=Droid+Sans|Droid+Sans+Mono|Droid+Serif);
 
 @media all
 {


### PR DESCRIPTION
When included on a page served from https://tuhdo.github.io, the font is not
loaded insecurely over http, so only default fonts are used.